### PR TITLE
create github action file for veracode upload&scan

### DIFF
--- a/.github/workflows/veracode-uploadscand.yml
+++ b/.github/workflows/veracode-uploadscand.yml
@@ -1,0 +1,29 @@
+name: Veracode Static Analysis Demo
+on: workflow_dispatch
+    
+jobs:
+  static_analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check out main branch
+        uses: actions/checkout@v2
+        
+        # To-Do add step for build/packaing
+        # refer to https://docs.veracode.com/r/compilation_java 
+          
+      - name: Veracode Upload And Scan
+        uses: veracode/veracode-uploadandscan-action@0.2.1
+        with:
+          appname: 'project-managed-identity-wallets'
+          createprofile: false
+          filepath: 'app/target/verademo.war' # add filepath for upload
+          vid: '${{ secrets.API_ID }}' # store and reference veracode API ID in github secrets
+          vkey: '${{ secrets.API_KEY }}' #store and reference veracode API KEY in github secrets
+#          createsandbox: 'true'
+#          sandboxname: 'SANDBOXNAME'
+#          scantimeout: 0
+#          exclude: '*.js'
+#          include: '*.war'
+#          criticality: 'VeryHigh'


### PR DESCRIPTION
Draft of yaml file for the Veracode Upload and Scan action.

To-Dos:

- Create / request API credenitals for veracode, if you don't have them already
- Store API credentials as github secrets (`VERACODE_API_ID` & `VERACODE_API_KEY`)
- Add a step before "Veracode Upload And Scan" for building and packaging the application. Refer to  [veracode documentation](https://docs.veracode.com/r/compilation_java)