### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+
+
+## Reporting a bug in Catena-X
+
+
+
+Report security bugs in Catena-X to "dl_CoP_IT_Security@catena-x.net".
+
+Your report will be acknowledged within 5 days, and you’ll receive a more detailed response to your report within 10 days indicating the next steps in handling your submission.
+
+After the initial reply to your report, the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement, and may ask for additional information or guidance surrounding the reported issue.
+
+Please do not report security bugs through public GitHub issues.
+
+
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+
+- Full paths of source file(s) related to the manifestation of the issue
+
+- The location of the affected source code (tag/branch/commit or direct URL)
+
+- Any special configuration required to reproduce the issue
+
+- Step-by-step instructions to reproduce the issue
+
+- Proof-of-concept or exploit code (if possible)
+
+- Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+
+
+## Reporting a bug in a third party module
+
+Security bugs in third party modules should be reported to their respective maintainers.
+
+
+
+## Disclosure policy
+
+Here is the security disclosure policy for Catena-X.
+
+- The security report is received and is assigned a primary handler. 
+
+- This person will coordinate the fix and release process. 
+
+- Fixes are prepared for all releases which are still under maintenance. 
+
+- A suggested embargo date for this vulnerability is chosen. Typically the embargo date will be set to 72 hours. However, this may vary depending on the severity of the bug or difficulty in applying a fix.
+
+This process can take some time, especially when coordination is required with maintainers of other projects. 
+Every effort will be made to handle the bug in as timely a manner as possible; however, it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.


### PR DESCRIPTION
## Purpose of security policy
To give people instructions for reporting security vulnerabilities in your project, you can add a `SECURITY.md` file to your repository's root, `docs`, or `.github` folder. When someone creates an issue in your repository, they will see a link to your project's security policy.

> **Tip**: To help people find your security policy, you can link to your `SECURITY.md` file from other places in your repository, such as your `README` file.

This is the template provided by the Catena-X Security Expert team.