### PR TITLE
added security context to fix checkov findings

### DIFF
--- a/dev-assets/acapy-postgres/postgres-acapy-deployment.yml
+++ b/dev-assets/acapy-postgres/postgres-acapy-deployment.yml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: postgres-acapy-2
     spec:
+      securityContext:
+        runAsNonRoot: true #requires the container to run without root privilege - fix for Checkov Check ID: CKV_K8S_23
       volumes:
         - name: postgres-pv-acapy-storage
           persistentVolumeClaim:
@@ -19,6 +21,8 @@ spec:
       containers:
         - name: postgres-acapy-2
           image: postgres:11
+          securityContext:
+            allowPrivilegeEscalation: false #prevents RunAsUser commands to bypass their existing permissions - fix for Checkov Check ID: CKV_K8S_20
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432


### PR DESCRIPTION
Added securityContext parameters for pod (`runAsNonRoot = true`) and for container (`allowPrivilegeEscalation = false`) to fix current findings from checkov