### PR TITLE
Veracode action

### DIFF
--- a/.github/workflows/service-build.yaml
+++ b/.github/workflows/service-build.yaml
@@ -84,14 +84,10 @@ jobs:
           appname: 'project-managed-identity-wallets'
           createprofile: false
           filepath: 'build/install/net.catenax.core.managedidentitywallets/lib/*' # add filepath for upload
-          vid: '${{ secrets.VERACODE_API_ID }}' # store and reference veracode API ID in github secrets
-          vkey: '${{ secrets.VERACODE_API_KEY }}' #store and reference veracode API KEY in github secrets
+          vid: '${{ secrets.ORG_VERACODE_API_ID }}' # reference to API ID, which is set as github org. secret
+          vkey: '${{ secrets.ORG_VERACODE_API_KEY }}' #reference to API Key in github, which is set as github or. secret
           include: 'build/install/net.catenax.core.managedidentitywallets/lib/net.catenax.core.managedidentitywallets-*jar'
-#          createsandbox: 'true'
-#          sandboxname: 'SANDBOXNAME'
-#          scantimeout: 0
-#          exclude: '*.js'
-#          criticality: 'VeryHigh'
+
 
       - name: setup nodejs
         uses: actions/setup-node@master

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -58,11 +58,6 @@ jobs:
           appname: 'project-managed-identity-wallets'
           createprofile: false
           filepath: 'build/install/net.catenax.core.managedidentitywallets/lib/*' # add filepath for upload
-          vid: '${{ secrets.VERACODE_API_ID }}' # store and reference veracode API ID in github secrets
-          vkey: '${{ secrets.VERACODE_API_KEY }}' #store and reference veracode API KEY in github secrets
+          vid: '${{ secrets.ORG_VERACODE_API_ID }}' # reference to API ID, which is set as github org. secret
+          vkey: '${{ secrets.ORG_VERACODE_API_KEY }}' #reference to API Key in github, which is set as github or. secret
           include: 'build/install/net.catenax.core.managedidentitywallets/lib/net.catenax.core.managedidentitywallets-*jar'
-#          createsandbox: 'true'
-#          sandboxname: 'SANDBOXNAME'
-#          scantimeout: 0
-#          exclude: '*.js'
-#          criticality: 'VeryHigh'


### PR DESCRIPTION
I've changed the API Keys for the Veracode Upload&Scan action in the following to github action files:

- service-build.yaml
- veracode.yaml

We are now using the organization-wide API keys, which are stored as github organization secrets.